### PR TITLE
Checking if connection to Curse was made.

### DIFF
--- a/src/main/java/com/hearthproject/oneclient/util/curse/CurseUtils.java
+++ b/src/main/java/com/hearthproject/oneclient/util/curse/CurseUtils.java
@@ -126,6 +126,9 @@ public class CurseUtils {
 			}
 			String finalURL = url + path + filter;
 			return Jsoup.connect(finalURL).get();
+		} catch (java.net.SocketException socketEX) {
+			OneClientLogging.logger.info("Error connecting to Curse resources.  Continuing on.");
+			return new Document("https://google.com");
 		} catch (IOException e) {
 			OneClientLogging.error(e);
 		}


### PR DESCRIPTION
Add in "catch" during "getHTML" that verifies if connection to Curse was successful.  If not, log error and continue on.  Do not prevent client from actually loading.